### PR TITLE
fix : legend item ellipsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ In order to render a legend, you construct a legend renderer like this:
         overflow: 'auto',
         styles: [style],
         size: [600, 300],
-        iconSize: [15, 15]
+        iconSize: [15, 15],
+        iconSize: [15, 15],
+        legendItemTextSize: 14
       });
       renderer.render(someElement);
 ```
@@ -44,6 +46,8 @@ If the `maxColumnHeight` property is not set, the renderer will render just
 one column with all the legends, thus ignoring the size parameter for the height.
 
 The `size` and `iconSize` parameters refer to the legend overlay size and the legend icons size respectively.
+
+The `legendItemTextSize` refers to the legend item associated text font size. It's optionnal.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ In order to render a legend, you construct a legend renderer like this:
         styles: [style],
         size: [600, 300],
         iconSize: [15, 15],
-        iconSize: [15, 15],
         legendItemTextSize: 14
       });
       renderer.render(someElement);
@@ -47,7 +46,7 @@ one column with all the legends, thus ignoring the size parameter for the height
 
 The `size` and `iconSize` parameters refer to the legend overlay size and the legend icons size respectively.
 
-The `legendItemTextSize` refers to the legend item associated text font size. It's optionnal.
+The `legendItemTextSize` refers to the legend item's associated text font size. It's optional.
 
 ## Development
 

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -6,10 +6,13 @@ const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
   resources: 'usable'
 });
 
+
 global.window = dom.window;
 global.document = dom.window.document;
 global.navigator = dom.window.navigator;
 global.Image = dom.window.Image;
+global.Element = dom.window.Element;
+global.getComputedStyle = dom.window.getComputedStyle;
 global.HTMLCanvasElement = dom.window.HTMLCanvasElement;
 global.CanvasRenderingContext2D = dom.window.CanvasRenderingContext2D;
 global.SVGElement = dom.window.SVGElement;

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -6,7 +6,6 @@ const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
   resources: 'usable'
 });
 
-
 global.window = dom.window;
 global.document = dom.window.document;
 global.navigator = dom.window.navigator;

--- a/src/LegendRenderer/AbstractOutput.ts
+++ b/src/LegendRenderer/AbstractOutput.ts
@@ -2,12 +2,13 @@ abstract class AbstractOutput {
   protected constructor(
     protected size: [number, number],
     protected maxColumnWidth: number | null,
-    protected maxColumnHeight: number | null
+    protected maxColumnHeight: number | null,
+    protected legendItemTextSize: number | undefined
   ) {}
   abstract useContainer(title: string): void;
   abstract useRoot(): void;
   abstract addTitle(text: string, x: number|string, y: number|string): void;
-  abstract addLabel(text: string, x: number|string, y: number|string): void;
+  abstract addLabel(text: string, x: number|string, y: number|string, legendItemTextSize: number | undefined): void;
   abstract addImage(
     dataUrl: string,
     imgWidth: number,

--- a/src/LegendRenderer/LegendRenderer.spec.ts
+++ b/src/LegendRenderer/LegendRenderer.spec.ts
@@ -14,9 +14,10 @@ class MockOutput extends AbstractOutput {
   constructor(
     protected size: [number, number],
     protected maxColumnWidth: number | null,
-    protected maxColumnHeight: number | null
+    protected maxColumnHeight: number | null,
+    protected legendItemTextSize: number | undefined
   ) {
-    super(size, maxColumnWidth, maxColumnHeight);
+    super(size, maxColumnWidth, maxColumnHeight, legendItemTextSize);
   }
 }
 
@@ -96,7 +97,7 @@ describe('LegendRenderer', () => {
     const renderer = new LegendRenderer({
       size: [0, 0]
     });
-    const output = new MockOutput([0, 0], null, null);
+    const output = new MockOutput([0, 0], null, null, undefined);
     const returnValue = await renderer.renderLegendItem(output, {
       title: 'Example',
       rule: {
@@ -113,7 +114,7 @@ describe('LegendRenderer', () => {
     const renderer = new LegendRenderer({
       size: [0, 0]
     });
-    const output = new MockOutput([0, 0], null, null);
+    const output = new MockOutput([0, 0], null, null, undefined);
     await renderer.renderLegendItem(output, {
       title: 'Example',
       rule: {
@@ -125,7 +126,7 @@ describe('LegendRenderer', () => {
       }
     }, [0, 0], [45, 30]);
     expect(output.useContainer).toHaveBeenCalledWith('Example');
-    expect(output.addLabel).toHaveBeenCalledWith('Example', 50, (30 / 2) + 5);
+    expect(output.addLabel).toHaveBeenCalledWith('Example', 50, (30 / 2) + 5, undefined);
   });
 
   it('renders legend with a single non-empty legend item', async () => {

--- a/src/LegendRenderer/LegendRenderer.ts
+++ b/src/LegendRenderer/LegendRenderer.ts
@@ -44,6 +44,7 @@ interface LegendsConfiguration {
   overflow?: 'auto' | 'group';
   hideRect?: boolean;
   iconSize?: [number, number];
+  legendItemTextSize?: number;
 }
 
 const defaultIconSize: [number, number] = [45, 30];
@@ -107,7 +108,8 @@ export class LegendRenderer {
     const {
       hideRect,
       maxColumnHeight,
-      maxColumnWidth
+      maxColumnWidth,
+      legendItemTextSize
     } = this.config;
 
     if (item.rule) {
@@ -115,7 +117,8 @@ export class LegendRenderer {
       return this.getRuleIcon(item.rule)
         .then(async (uri) => {
           await output.addImage(uri, ...iconSize, position[0] + 1, position[1], !hideRect);
-          output.addLabel(item.title, position[0] + iconSize[0] + 5, position[1] + (iconSize[1] / 2) + 5);
+          output.addLabel(item.title, position[0] + iconSize[0] + 5,
+            position[1] + (iconSize[1] / 2) + 5, legendItemTextSize);
           position[1] += iconSize[1] + 5;
           if (maxColumnHeight && position[1] + iconSize[1] + 5 >= maxColumnHeight) {
             position[1] = 5;
@@ -335,6 +338,7 @@ export class LegendRenderer {
       remoteLegends,
       maxColumnWidth,
       maxColumnHeight,
+      legendItemTextSize
     } = this.config;
     const legends: LegendConfiguration[] = [];
     if (styles) {
@@ -344,7 +348,8 @@ export class LegendRenderer {
       legends.unshift.apply(legends, configs);
     }
     const outputClass = format === 'svg' ? SvgOutput : PngOutput;
-    const output = new outputClass([width, height], maxColumnWidth || 0, maxColumnHeight || 0, target);
+    const output = new outputClass([width, height], maxColumnWidth || 0, maxColumnHeight || 0,
+      legendItemTextSize, target);
     const position: [number, number] = [0, 0];
     for (let i = 0; i < legends.length; i++) {
       await this.renderLegend(legends[i], output, position);

--- a/src/LegendRenderer/PngOutput.spec.ts
+++ b/src/LegendRenderer/PngOutput.spec.ts
@@ -24,7 +24,7 @@ describe('PngOutput', () => {
 
   describe('individual actions', () => {
     beforeEach(() => {
-      output = new PngOutput([500, 700], null, null);
+      output = new PngOutput([500, 700], null, null, undefined);
       vi.spyOn(output.context, 'drawImage');
       vi.spyOn(output.context, 'fillText');
       vi.spyOn(output.context, 'strokeRect');
@@ -39,8 +39,8 @@ describe('PngOutput', () => {
     });
     describe('#addLabel', () => {
       it('inserts a label', () => {
-        output.addLabel('My Label', 100, 150);
-        expect(output.context.fillText).toHaveBeenCalledWith('My Label', 100, 150);
+        output.addLabel('My Label', 100, 150, 14);
+        expect(output.context.fillText).toHaveBeenCalledWith('My Label', 100, 150, 14);
         expect(output.context.fillStyle).toEqual('#000000');
       });
     });
@@ -101,7 +101,7 @@ describe('PngOutput', () => {
     let root: HTMLDivElement;
     beforeEach(() => {
       root = document.createElement('div');
-      output = new PngOutput([500, 700], 250, 500, root);
+      output = new PngOutput([500, 700], 250, 500, undefined, root);
     });
     it('appends the output to the target element', () => {
       output.generate(123);

--- a/src/LegendRenderer/PngOutput.ts
+++ b/src/LegendRenderer/PngOutput.ts
@@ -2,13 +2,16 @@ import AbstractOutput from './AbstractOutput';
 
 const ROOT_CLASS = 'geostyler-legend-renderer';
 
-function cssDimensionToPx(dimension: string | number): number {
+function cssDimensionToPx(dimension: string | number, legendItemTextSize: number | undefined = undefined): number {
   if (typeof dimension === 'number') {
     return dimension;
   }
   const div = document.createElement('div');
   document.body.append(div);
   div.style.height = dimension;
+  if (legendItemTextSize) {
+    div.style.fontSize = legendItemTextSize + "px";
+  }
   const height = parseFloat(getComputedStyle(div).height.replace(/px$/, ''));
   div.remove();
   return height;
@@ -22,9 +25,10 @@ export default class PngOutput extends AbstractOutput {
     size: [number, number],
     maxColumnWidth: number | null,
     maxColumnHeight: number | null,
+    legendItemTextSize: number | undefined,
     private target?: HTMLElement,
   ) {
-    super(size, maxColumnWidth, maxColumnHeight);
+    super(size, maxColumnWidth, maxColumnHeight, legendItemTextSize);
     this.createCanvas(...size);
   }
 
@@ -36,8 +40,8 @@ export default class PngOutput extends AbstractOutput {
     this.context.fillText(text, cssDimensionToPx(x), cssDimensionToPx(y));
   }
 
-  addLabel(text: string, x: number | string, y: number | string) {
-    this.context.fillText(text, cssDimensionToPx(x), cssDimensionToPx(y));
+  addLabel(text: string, x: number | string, y: number | string, legendItemTextSize: number | undefined) {
+    this.context.fillText(text, cssDimensionToPx(x), cssDimensionToPx(y), legendItemTextSize);
   }
 
   async addImage(

--- a/src/LegendRenderer/SvgOutput.spec.ts
+++ b/src/LegendRenderer/SvgOutput.spec.ts
@@ -9,28 +9,6 @@ import {
   SAMPLE_OUTPUT_FINAL_HEIGHT
 } from '../fixtures/outputs';
 
-// mock getBoundingClientRect on created DOM elements
-// (by default jsdom always return 0 so there's no way to test label shortening)
-(document as any).originalCreateElementNS = document.createElementNS;
-document.createElementNS = function(namespace: string, eltName: string) {
-  const el = (document as any).originalCreateElementNS(namespace, eltName);
-  el.getBoundingClientRect = function(): DOMRect {
-    const charCount = this.textContent.length;
-    return {
-      height: 10,
-      width: charCount * 6,
-      x: 0,
-      y: 0,
-      left: 0,
-      top: 0,
-      bottom: 0,
-      right: 0,
-      toJSON: () => ''
-    };
-  };
-  return el;
-};
-
 describe('SvgOutput', () => {
   let output: SvgOutput;
 
@@ -40,7 +18,7 @@ describe('SvgOutput', () => {
 
   describe('individual actions', () => {
     beforeEach(() => {
-      output = new SvgOutput([500, 700], undefined, undefined);
+      output = new SvgOutput([500, 700], undefined, undefined, undefined);
     });
 
     describe('#useContainer', () => {
@@ -72,9 +50,9 @@ describe('SvgOutput', () => {
     });
     describe('#addLabel', () => {
       it('inserts a label', () => {
-        output.addLabel('My Label', 100, 150);
+        output.addLabel('My Label', 100, 150, 14);
         expect(output.generate(SAMPLE_OUTPUT_FINAL_HEIGHT).innerHTML).toEqual(
-          '<text x="100" y="150">My Label</text>'
+          '<text x="100" y="150" style="font-size: 14px;">My Label</text>'
         );
       });
     });
@@ -97,7 +75,7 @@ describe('SvgOutput', () => {
 
   describe('without column constraints', () => {
     beforeEach(async () => {
-      output = new SvgOutput([500, 700], undefined, undefined);
+      output = new SvgOutput([500, 700], undefined, undefined, undefined);
       await makeSampleOutput(output);
     });
     it('generates the right output', () => {
@@ -107,7 +85,7 @@ describe('SvgOutput', () => {
 
   describe('with column constraints', () => {
     beforeEach(async () => {
-      output = new SvgOutput([500, 700], 50, 200);
+      output = new SvgOutput([500, 700], 50, 200, undefined);
       await makeSampleOutput(output);
     });
     it('generates the right output', () => {
@@ -117,7 +95,7 @@ describe('SvgOutput', () => {
 
   describe('with a height too low', () => {
     beforeEach(async () => {
-      output = new SvgOutput([500, 200], 50, 200);
+      output = new SvgOutput([500, 200], 50, 200, undefined);
       await makeSampleOutput(output);
     });
     it('sets the height on the final canvas', () => {
@@ -131,7 +109,7 @@ describe('SvgOutput', () => {
     let root: HTMLDivElement;
     beforeEach(() => {
       root = document.createElement('div');
-      output = new SvgOutput([500, 700], 250, 500, root);
+      output = new SvgOutput([500, 700], 250, 500, undefined, root);
     });
     it('appends the output to the target element', () => {
       output.generate(123);

--- a/src/LegendRenderer/SvgOutput.ts
+++ b/src/LegendRenderer/SvgOutput.ts
@@ -65,11 +65,15 @@ export default class SvgOutput extends AbstractOutput {
   }
 
   addLabel(text: string, x: number | string, y: number | string, legendItemTextSize: number | undefined) {
-    this.currentContainer?.append('text')
-      .text(text)
-      .attr('x', x)
-      .attr('y', y)
-      .style('font-size', legendItemTextSize + 'px');
+    const textElement = this.currentContainer?.append('text');
+    if (textElement) {
+      textElement.text(text)
+        .attr('x', x)
+        .attr('y', y);
+      if (legendItemTextSize !== undefined) {
+        textElement.style('font-size', legendItemTextSize + 'px');
+      }
+    }
   };
 
   addImage(

--- a/src/fixtures/outputs.ts
+++ b/src/fixtures/outputs.ts
@@ -8,17 +8,17 @@ export const SAMPLE_IMAGE_SRC = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA
 export async function makeSampleOutput(output: AbstractOutput) {
   output.useContainer('My Container');
   output.addTitle('Inside a container', 180, 180);
-  output.addLabel('An image in a container', 200, 220);
+  output.addLabel('An image in a container', 200, 220, undefined);
   await output.addImage(SAMPLE_IMAGE_SRC, 100, 50, 200, 250, false);
   output.useRoot();
   output.addTitle('Outside a container', 180, 480);
-  output.addLabel('An image', 200, 520);
+  output.addLabel('An image', 200, 520, undefined);
   await output.addImage(SAMPLE_IMAGE_SRC, 100, 50, 200, 550, true);
 }
 
 export const SAMPLE_OUTPUT_FINAL_HEIGHT = 600;
 
-export const SAMPLE_SVG = '<svg class="geostyler-legend-renderer" viewBox="0 0 500 600" top="0" left="0" width="500" height="600" xmlns="http://www.w3.org/2000/svg"><g class="legend-item" title="My Container"><g><text class="legend-title" text-anchor="start" dx="180" dy="180">...</text></g><text x="200" y="220">An image in a container</text><image x="200" y="250" width="100" height="50" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjyHNz+g8ABBIB9kHiDqIAAAAASUVORK5CYII="></image></g><g><text class="legend-title" text-anchor="start" dx="180" dy="480">Outside a container</text></g><text x="200" y="520">An image</text><rect x="200" y="550" width="100" height="50" style="fill-opacity: 0; stroke: black;"></rect><image x="200" y="550" width="100" height="50" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjyHNz+g8ABBIB9kHiDqIAAAAASUVORK5CYII="></image></svg>';
+export const SAMPLE_SVG = '<svg class="geostyler-legend-renderer" viewBox="0 0 500 600" top="0" left="0" width="500" height="600" xmlns="http://www.w3.org/2000/svg"><g class="legend-item" title="My Container"><g><text class="legend-title" text-anchor="start" dx="180" dy="180">...</text><title>Inside a container</title></g><text x="200" y="220">An image in a container</text><image x="200" y="250" width="100" height="50" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjyHNz+g8ABBIB9kHiDqIAAAAASUVORK5CYII="></image></g><g><text class="legend-title" text-anchor="start" dx="180" dy="480">Outside a container</text></g><text x="200" y="520">An image</text><rect x="200" y="550" width="100" height="50" style="fill-opacity: 0; stroke: black;"></rect><image x="200" y="550" width="100" height="50" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjyHNz+g8ABBIB9kHiDqIAAAAASUVORK5CYII="></image></svg>';
 
 // max column width: 50, max column height: 200
 export const SAMPLE_SVG_COLUMN_CONSTRAINTS =
@@ -26,7 +26,8 @@ export const SAMPLE_SVG_COLUMN_CONSTRAINTS =
   'xmlns="http://www.w3.org/2000/svg">' +
   '<g class="legend-item" title="My Container">' +
   '<g>' +
-  '<text class="legend-title" text-anchor="start" dx="180" dy="180">Insid...</text>' +
+  '<text class="legend-title" text-anchor="start" dx="180" dy="180">Inside ...</text>' +
+  '<title>Inside a container</title>' +
   '</g>' +
   '<text x="200" y="220">An image in a container</text>' +
   '<image x="200" y="250" width="100" height="50" href="' + SAMPLE_IMAGE_SRC + '"></image>' +


### PR DESCRIPTION
Work done : 

- Add ellipsis if text is overflow column width and add title tag to see full text
- Add possibility to set font size
- Update README with the new parameter

This improvement allows to build legend and display it after rendering for export by example.
It calculates the width of the legend item and replace legend item text by three dots if the text overflown. The width can depends on define font size. If no font size provided, the html body font size is used.

Before we cannot read easily legend if the text was long : 

<img width="1429" height="698" alt="image" src="https://github.com/user-attachments/assets/45535c57-c686-4dc4-89e9-a2582debea17" />

Now the text is ellipsed and if user hover the legend item, he could see the full text : 

<img width="1432" height="692" alt="image" src="https://github.com/user-attachments/assets/8ce08bca-5596-4602-adc1-da9177249625" />

Code sample used :

```typescript
const renderer = new LegendRenderer({
  maxColumnWidth: COLUMN_WIDTH,
  maxColumnHeight: COLUMN_HEIGHT,
  overflow: auto,
  styles: [geostylerStyle.output,
  size: [COLUMN_WIDTH * 2, COLUMN_HEIGHT],
  hideRect: true,
  iconSize: [15, 15],
  legendItemTextSize: 14
});
```